### PR TITLE
CONI-2: Add production improvements - model cache, server control, API extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "mlx-lm>=0.5.0",
     "huggingface-hub>=0.19.0",
     "rich>=13.0.0",
+    "cachetools>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/mlx_serve/config.py
+++ b/src/mlx_serve/config.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -32,6 +32,34 @@ class Settings(BaseSettings):
         default="INFO",
         description="Log level",
     )
+
+    # Cache settings
+    cache_max_embedding_models: int = Field(
+        default=3,
+        description="Maximum number of embedding models to keep in cache (LRU)",
+    )
+    cache_max_reranker_models: int = Field(
+        default=2,
+        description="Maximum number of reranker models to keep in cache (LRU)",
+    )
+    cache_ttl_seconds: int = Field(
+        default=1800,
+        description="Time-to-live for cached models in seconds (30 minutes default)",
+    )
+
+    # Preload settings
+    preload_models: list[str] = Field(
+        default_factory=list,
+        description="List of model names to preload at startup",
+    )
+
+    @field_validator("preload_models", mode="before")
+    @classmethod
+    def parse_preload_models(cls, v):
+        """Parse preload_models from comma-separated string or list."""
+        if isinstance(v, str):
+            return [m.strip() for m in v.split(",") if m.strip()]
+        return v
 
     def ensure_dirs(self) -> None:
         """Ensure required directories exist."""

--- a/src/mlx_serve/core/model_manager.py
+++ b/src/mlx_serve/core/model_manager.py
@@ -3,11 +3,14 @@
 import json
 import logging
 import shutil
-from dataclasses import dataclass, field
+import threading
+import time
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, AsyncIterator, Literal
 
+from cachetools import LRUCache
 from huggingface_hub import snapshot_download
 
 from mlx_serve.config import settings
@@ -29,12 +32,77 @@ class ModelInfo:
     hf_repo: str = ""
 
 
-@dataclass
-class ModelCache:
-    """Cache for loaded models."""
+class TTLLRUCache:
+    """LRU cache with TTL (Time-To-Live) support."""
 
-    embeddings: dict[str, Any] = field(default_factory=dict)
-    rerankers: dict[str, Any] = field(default_factory=dict)
+    def __init__(self, maxsize: int, ttl: int):
+        """Initialize cache with max size and TTL in seconds."""
+        self._cache: LRUCache = LRUCache(maxsize=maxsize)
+        self._timestamps: dict[str, float] = {}
+        self._ttl = ttl
+        self._lock = threading.RLock()
+
+    def get(self, key: str) -> Any | None:
+        """Get item from cache, returning None if expired or not found."""
+        with self._lock:
+            if key not in self._cache:
+                return None
+
+            # Check TTL
+            if self._is_expired(key):
+                self._remove(key)
+                return None
+
+            # Update timestamp on access (refresh TTL)
+            self._timestamps[key] = time.time()
+            return self._cache[key]
+
+    def set(self, key: str, value: Any) -> None:
+        """Set item in cache with current timestamp."""
+        with self._lock:
+            self._cache[key] = value
+            self._timestamps[key] = time.time()
+
+    def remove(self, key: str) -> bool:
+        """Remove item from cache."""
+        with self._lock:
+            return self._remove(key)
+
+    def _remove(self, key: str) -> bool:
+        """Internal remove without lock."""
+        if key in self._cache:
+            del self._cache[key]
+            self._timestamps.pop(key, None)
+            return True
+        return False
+
+    def _is_expired(self, key: str) -> bool:
+        """Check if an item has expired."""
+        if key not in self._timestamps:
+            return True
+        return (time.time() - self._timestamps[key]) > self._ttl
+
+    def cleanup_expired(self) -> list[str]:
+        """Remove all expired items and return their keys."""
+        with self._lock:
+            expired = [k for k in list(self._cache.keys()) if self._is_expired(k)]
+            for key in expired:
+                self._remove(key)
+            return expired
+
+    def keys(self) -> list[str]:
+        """Return list of keys in cache."""
+        with self._lock:
+            return list(self._cache.keys())
+
+    def __contains__(self, key: str) -> bool:
+        """Check if key is in cache and not expired."""
+        return self.get(key) is not None
+
+    def __len__(self) -> int:
+        """Return number of items in cache."""
+        with self._lock:
+            return len(self._cache)
 
 
 class ModelManager:
@@ -53,12 +121,38 @@ class ModelManager:
             return
 
         self._initialized = True
-        self._cache = ModelCache()
+        self._embedding_cache = TTLLRUCache(
+            maxsize=settings.cache_max_embedding_models,
+            ttl=settings.cache_ttl_seconds,
+        )
+        self._reranker_cache = TTLLRUCache(
+            maxsize=settings.cache_max_reranker_models,
+            ttl=settings.cache_ttl_seconds,
+        )
         self._metadata_path = settings.models_dir.parent / "metadata.json"
         self._metadata: dict[str, dict] = {}
 
         settings.ensure_dirs()
         self._load_metadata()
+
+        # Start background cleanup thread
+        self._start_cleanup_thread()
+
+    def _start_cleanup_thread(self) -> None:
+        """Start background thread for TTL cleanup."""
+
+        def cleanup_loop():
+            while True:
+                time.sleep(60)  # Check every minute
+                expired_embeddings = self._embedding_cache.cleanup_expired()
+                expired_rerankers = self._reranker_cache.cleanup_expired()
+                if expired_embeddings:
+                    logger.info(f"Cleaned up expired embedding models: {expired_embeddings}")
+                if expired_rerankers:
+                    logger.info(f"Cleaned up expired reranker models: {expired_rerankers}")
+
+        thread = threading.Thread(target=cleanup_loop, daemon=True)
+        thread.start()
 
     def _load_metadata(self) -> None:
         """Load model metadata from disk."""
@@ -178,8 +272,8 @@ class ModelManager:
         model_dir = self._get_model_dir(model_name)
 
         # Remove from cache
-        self._cache.embeddings.pop(model_name, None)
-        self._cache.rerankers.pop(model_name, None)
+        self._embedding_cache.remove(model_name)
+        self._reranker_cache.remove(model_name)
 
         # Remove from metadata
         if model_name in self._metadata:
@@ -195,35 +289,109 @@ class ModelManager:
 
     def get_embedding_model(self, model_name: str) -> Any:
         """Get or load an embedding model."""
-        if model_name in self._cache.embeddings:
-            return self._cache.embeddings[model_name]
+        cached = self._embedding_cache.get(model_name)
+        if cached is not None:
+            logger.debug(f"Embedding model cache hit: {model_name}")
+            return cached
 
         model_dir = self._get_model_dir(model_name)
         if not model_dir.exists():
             raise ValueError(f"Model '{model_name}' not found")
+
+        logger.info(f"Loading embedding model: {model_name}")
 
         # Import here to avoid loading MLX at module import time
         from mlx_embeddings import load
 
         model, tokenizer = load(str(model_dir))
-        self._cache.embeddings[model_name] = (model, tokenizer)
+        self._embedding_cache.set(model_name, (model, tokenizer))
         return model, tokenizer
 
     def get_reranker_model(self, model_name: str) -> Any:
         """Get or load a reranker model."""
-        if model_name in self._cache.rerankers:
-            return self._cache.rerankers[model_name]
+        cached = self._reranker_cache.get(model_name)
+        if cached is not None:
+            logger.debug(f"Reranker model cache hit: {model_name}")
+            return cached
 
         model_dir = self._get_model_dir(model_name)
         if not model_dir.exists():
             raise ValueError(f"Model '{model_name}' not found")
 
+        logger.info(f"Loading reranker model: {model_name}")
+
         # Import here to avoid loading MLX at module import time
         from mlx_lm import load
 
         model, tokenizer = load(str(model_dir))
-        self._cache.rerankers[model_name] = (model, tokenizer)
+        self._reranker_cache.set(model_name, (model, tokenizer))
         return model, tokenizer
+
+    def get_cache_stats(self) -> dict:
+        """Get cache statistics."""
+        return {
+            "embedding_models": {
+                "count": len(self._embedding_cache),
+                "max_size": settings.cache_max_embedding_models,
+                "models": self._embedding_cache.keys(),
+            },
+            "reranker_models": {
+                "count": len(self._reranker_cache),
+                "max_size": settings.cache_max_reranker_models,
+                "models": self._reranker_cache.keys(),
+            },
+            "ttl_seconds": settings.cache_ttl_seconds,
+        }
+
+    def preload_model(self, model_name: str) -> bool:
+        """Preload a model into cache.
+
+        Args:
+            model_name: Name of the model to preload.
+
+        Returns:
+            True if model was successfully loaded, False otherwise.
+        """
+        if not self.is_model_installed(model_name):
+            logger.warning(f"Model '{model_name}' not installed, cannot preload")
+            return False
+
+        model_info = self.get_model_info(model_name)
+        if model_info is None:
+            logger.warning(f"Model '{model_name}' info not found, cannot preload")
+            return False
+
+        try:
+            if model_info.model_type == "embedding":
+                self.get_embedding_model(model_name)
+                logger.info(f"Preloaded embedding model: {model_name}")
+            elif model_info.model_type == "reranker":
+                self.get_reranker_model(model_name)
+                logger.info(f"Preloaded reranker model: {model_name}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to preload model '{model_name}': {e}")
+            return False
+
+    def preload_models(self, model_names: list[str] | None = None) -> dict[str, bool]:
+        """Preload multiple models.
+
+        Args:
+            model_names: List of model names to preload. If None, uses settings.preload_models.
+
+        Returns:
+            Dict mapping model names to success status.
+        """
+        if model_names is None:
+            model_names = settings.preload_models
+
+        if not model_names:
+            return {}
+
+        results = {}
+        for model_name in model_names:
+            results[model_name] = self.preload_model(model_name)
+        return results
 
 
 # Global instance

--- a/src/mlx_serve/core/pid_manager.py
+++ b/src/mlx_serve/core/pid_manager.py
@@ -1,0 +1,172 @@
+"""PID file management for mlx-serve server instances."""
+
+import os
+import signal
+from pathlib import Path
+
+
+class PIDManager:
+    """Manage PID files for mlx-serve server instances."""
+
+    def __init__(self, port: int):
+        """Initialize PID manager for a specific port.
+
+        Args:
+            port: The port number the server is running on.
+        """
+        self.port = port
+        self._pid_dir = Path.home() / ".mlx-serve"
+        self._pid_file = self._pid_dir / f"mlx-serve-{port}.pid"
+
+    @property
+    def pid_file(self) -> Path:
+        """Get the PID file path."""
+        return self._pid_file
+
+    def write_pid(self, pid: int | None = None) -> None:
+        """Write the current process PID to file.
+
+        Args:
+            pid: Process ID to write. Defaults to current process PID.
+        """
+        self._pid_dir.mkdir(parents=True, exist_ok=True)
+        pid = pid if pid is not None else os.getpid()
+        self._pid_file.write_text(str(pid))
+
+    def read_pid(self) -> int | None:
+        """Read PID from file.
+
+        Returns:
+            The PID if file exists and is valid, None otherwise.
+        """
+        if not self._pid_file.exists():
+            return None
+
+        try:
+            return int(self._pid_file.read_text().strip())
+        except (ValueError, OSError):
+            return None
+
+    def remove_pid(self) -> bool:
+        """Remove the PID file.
+
+        Returns:
+            True if file was removed, False otherwise.
+        """
+        if self._pid_file.exists():
+            self._pid_file.unlink()
+            return True
+        return False
+
+    def is_process_running(self, pid: int | None = None) -> bool:
+        """Check if a process with the given PID is running.
+
+        Args:
+            pid: Process ID to check. If None, reads from PID file.
+
+        Returns:
+            True if process is running, False otherwise.
+        """
+        if pid is None:
+            pid = self.read_pid()
+
+        if pid is None:
+            return False
+
+        try:
+            # Send signal 0 to check if process exists
+            os.kill(pid, 0)
+            return True
+        except (OSError, ProcessLookupError):
+            return False
+
+    def is_stale(self) -> bool:
+        """Check if the PID file is stale (process not running).
+
+        Returns:
+            True if PID file exists but process is not running.
+        """
+        pid = self.read_pid()
+        if pid is None:
+            return False
+        return not self.is_process_running(pid)
+
+    def cleanup_stale(self) -> bool:
+        """Remove PID file if it's stale.
+
+        Returns:
+            True if stale PID file was cleaned up, False otherwise.
+        """
+        if self.is_stale():
+            return self.remove_pid()
+        return False
+
+    def stop_server(self, force: bool = False, timeout: int = 30) -> bool:
+        """Stop the server by sending signals.
+
+        Args:
+            force: If True, send SIGKILL immediately. Otherwise, try SIGTERM first.
+            timeout: Seconds to wait for graceful shutdown before forcing.
+
+        Returns:
+            True if server was stopped, False if no server was running.
+        """
+        import time
+
+        pid = self.read_pid()
+        if pid is None:
+            return False
+
+        if not self.is_process_running(pid):
+            self.remove_pid()
+            return False
+
+        try:
+            if force:
+                os.kill(pid, signal.SIGKILL)
+            else:
+                # Try graceful shutdown first
+                os.kill(pid, signal.SIGTERM)
+
+                # Wait for process to terminate
+                for _ in range(timeout * 10):  # Check every 100ms
+                    time.sleep(0.1)
+                    if not self.is_process_running(pid):
+                        break
+                else:
+                    # Timeout - force kill
+                    os.kill(pid, signal.SIGKILL)
+                    time.sleep(0.5)
+
+            self.remove_pid()
+            return True
+        except (OSError, ProcessLookupError):
+            self.remove_pid()
+            return False
+
+
+def get_all_instances() -> list[tuple[int, int]]:
+    """Get all running mlx-serve instances.
+
+    Returns:
+        List of (port, pid) tuples for running instances.
+    """
+    pid_dir = Path.home() / ".mlx-serve"
+    if not pid_dir.exists():
+        return []
+
+    instances = []
+    for pid_file in pid_dir.glob("mlx-serve-*.pid"):
+        try:
+            port = int(pid_file.stem.split("-")[-1])
+            pid_manager = PIDManager(port)
+            pid = pid_manager.read_pid()
+            if pid and pid_manager.is_process_running(pid):
+                instances.append((port, pid))
+            else:
+                # Cleanup stale PID file
+                pid_manager.remove_pid()
+        except (ValueError, OSError):
+            continue
+
+    return instances

--- a/src/mlx_serve/core/service_manager.py
+++ b/src/mlx_serve/core/service_manager.py
@@ -1,0 +1,336 @@
+"""Cross-platform service management for mlx-serve."""
+
+import platform
+import subprocess
+import sys
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class ServiceManager(ABC):
+    """Abstract base class for OS-specific service managers."""
+
+    @property
+    @abstractmethod
+    def service_name(self) -> str:
+        """Return the service name."""
+        pass
+
+    @property
+    @abstractmethod
+    def is_installed(self) -> bool:
+        """Check if the service is installed."""
+        pass
+
+    @property
+    @abstractmethod
+    def is_running(self) -> bool:
+        """Check if the service is currently running."""
+        pass
+
+    @property
+    @abstractmethod
+    def is_enabled(self) -> bool:
+        """Check if the service is enabled to start at login."""
+        pass
+
+    @abstractmethod
+    def install(self) -> tuple[bool, str]:
+        """Install the service. Returns (success, message)."""
+        pass
+
+    @abstractmethod
+    def uninstall(self) -> tuple[bool, str]:
+        """Uninstall the service. Returns (success, message)."""
+        pass
+
+    @abstractmethod
+    def start(self) -> tuple[bool, str]:
+        """Start the service. Returns (success, message)."""
+        pass
+
+    @abstractmethod
+    def stop(self) -> tuple[bool, str]:
+        """Stop the service. Returns (success, message)."""
+        pass
+
+    @abstractmethod
+    def enable(self) -> tuple[bool, str]:
+        """Enable the service to start at login. Returns (success, message)."""
+        pass
+
+    @abstractmethod
+    def disable(self) -> tuple[bool, str]:
+        """Disable the service from starting at login. Returns (success, message)."""
+        pass
+
+    def status(self) -> dict:
+        """Get service status information."""
+        return {
+            "installed": self.is_installed,
+            "running": self.is_running,
+            "enabled": self.is_enabled,
+            "service_name": self.service_name,
+        }
+
+
+class LaunchdManager(ServiceManager):
+    """macOS launchd service manager."""
+
+    PLIST_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mlx-serve.server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{python_path}</string>
+        <string>-m</string>
+        <string>mlx_serve</string>
+        <string>start</string>
+        <string>--foreground</string>
+    </array>
+    <key>RunAtLoad</key>
+    <{run_at_load}/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{log_dir}/mlx-serve.log</string>
+    <key>StandardErrorPath</key>
+    <string>{log_dir}/mlx-serve.error.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>
+"""
+
+    def __init__(self):
+        self._plist_path = Path.home() / "Library" / "LaunchAgents" / "com.mlx-serve.server.plist"
+        self._log_dir = Path.home() / ".mlx-serve" / "logs"
+
+    @property
+    def service_name(self) -> str:
+        return "com.mlx-serve.server"
+
+    @property
+    def is_installed(self) -> bool:
+        return self._plist_path.exists()
+
+    @property
+    def is_running(self) -> bool:
+        result = subprocess.run(
+            ["launchctl", "list", self.service_name],
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0
+
+    @property
+    def is_enabled(self) -> bool:
+        if not self.is_installed:
+            return False
+        # Check RunAtLoad in plist
+        content = self._plist_path.read_text()
+        return "<key>RunAtLoad</key>\n    <true/>" in content
+
+    def install(self, run_at_load: bool = False) -> tuple[bool, str]:
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+        self._plist_path.parent.mkdir(parents=True, exist_ok=True)
+
+        plist_content = self.PLIST_TEMPLATE.format(
+            python_path=sys.executable,
+            log_dir=str(self._log_dir),
+            run_at_load="true" if run_at_load else "false",
+        )
+        self._plist_path.write_text(plist_content)
+        return True, f"Service installed at {self._plist_path}"
+
+    def uninstall(self) -> tuple[bool, str]:
+        self.stop()
+        if self._plist_path.exists():
+            self._plist_path.unlink()
+            return True, "Service uninstalled"
+        return True, "Service was not installed"
+
+    def start(self) -> tuple[bool, str]:
+        if not self.is_installed:
+            return False, "Service not installed. Run 'mlx-serve service install' first"
+
+        result = subprocess.run(
+            ["launchctl", "load", str(self._plist_path)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True, "Service started"
+        return False, f"Failed to start service: {result.stderr}"
+
+    def stop(self) -> tuple[bool, str]:
+        result = subprocess.run(
+            ["launchctl", "unload", str(self._plist_path)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True, "Service stopped"
+        return True, "Service may not be running"
+
+    def enable(self) -> tuple[bool, str]:
+        if not self.is_installed:
+            return False, "Service not installed"
+        # Reinstall with RunAtLoad=true
+        return self.install(run_at_load=True)
+
+    def disable(self) -> tuple[bool, str]:
+        if not self.is_installed:
+            return False, "Service not installed"
+        # Reinstall with RunAtLoad=false
+        return self.install(run_at_load=False)
+
+
+class SystemdManager(ServiceManager):
+    """Linux systemd user service manager."""
+
+    SERVICE_TEMPLATE = """[Unit]
+Description=MLX-Serve Embedding Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={python_path} -m mlx_serve start --foreground
+Restart=on-failure
+RestartSec=5
+Environment=PATH={home}/.local/bin:/usr/bin
+
+[Install]
+WantedBy=default.target
+"""
+
+    def __init__(self):
+        self._service_dir = Path.home() / ".config" / "systemd" / "user"
+        self._service_path = self._service_dir / "mlx-serve.service"
+
+    @property
+    def service_name(self) -> str:
+        return "mlx-serve"
+
+    @property
+    def is_installed(self) -> bool:
+        return self._service_path.exists()
+
+    @property
+    def is_running(self) -> bool:
+        result = subprocess.run(
+            ["systemctl", "--user", "is-active", self.service_name],
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip() == "active"
+
+    @property
+    def is_enabled(self) -> bool:
+        result = subprocess.run(
+            ["systemctl", "--user", "is-enabled", self.service_name],
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip() == "enabled"
+
+    def install(self) -> tuple[bool, str]:
+        self._service_dir.mkdir(parents=True, exist_ok=True)
+
+        service_content = self.SERVICE_TEMPLATE.format(
+            python_path=sys.executable,
+            home=Path.home(),
+        )
+        self._service_path.write_text(service_content)
+
+        # Reload systemd
+        subprocess.run(["systemctl", "--user", "daemon-reload"], capture_output=True)
+        return True, f"Service installed at {self._service_path}"
+
+    def uninstall(self) -> tuple[bool, str]:
+        self.stop()
+        self.disable()
+        if self._service_path.exists():
+            self._service_path.unlink()
+            subprocess.run(["systemctl", "--user", "daemon-reload"], capture_output=True)
+            return True, "Service uninstalled"
+        return True, "Service was not installed"
+
+    def start(self) -> tuple[bool, str]:
+        if not self.is_installed:
+            return False, "Service not installed. Run 'mlx-serve service install' first"
+
+        result = subprocess.run(
+            ["systemctl", "--user", "start", self.service_name],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True, "Service started"
+        return False, f"Failed to start service: {result.stderr}"
+
+    def stop(self) -> tuple[bool, str]:
+        result = subprocess.run(
+            ["systemctl", "--user", "stop", self.service_name],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True, "Service stopped"
+        return True, "Service may not be running"
+
+    def enable(self) -> tuple[bool, str]:
+        if not self.is_installed:
+            return False, "Service not installed"
+
+        result = subprocess.run(
+            ["systemctl", "--user", "enable", self.service_name],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True, "Service enabled (will start at login)"
+        return False, f"Failed to enable service: {result.stderr}"
+
+    def disable(self) -> tuple[bool, str]:
+        if not self.is_installed:
+            return False, "Service not installed"
+
+        result = subprocess.run(
+            ["systemctl", "--user", "disable", self.service_name],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True, "Service disabled (won't start at login)"
+        return False, f"Failed to disable service: {result.stderr}"
+
+
+def get_service_manager() -> ServiceManager | None:
+    """Get the appropriate service manager for the current OS.
+
+    Returns:
+        ServiceManager instance or None if unsupported OS.
+    """
+    system = platform.system()
+    if system == "Darwin":
+        return LaunchdManager()
+    elif system == "Linux":
+        return SystemdManager()
+    return None
+
+
+def get_platform_name() -> str:
+    """Get human-readable platform name."""
+    system = platform.system()
+    if system == "Darwin":
+        return "macOS (launchd)"
+    elif system == "Linux":
+        return "Linux (systemd)"
+    return system

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,157 @@
+"""Tests for TTL LRU cache."""
+
+import time
+
+import pytest
+
+from mlx_serve.core.model_manager import TTLLRUCache
+
+
+class TestTTLLRUCache:
+    """Test TTLLRUCache class."""
+
+    def test_set_and_get(self):
+        """Test basic set and get operations."""
+        cache = TTLLRUCache(maxsize=3, ttl=60)
+        cache.set("key1", "value1")
+        assert cache.get("key1") == "value1"
+
+    def test_get_nonexistent(self):
+        """Test getting non-existent key."""
+        cache = TTLLRUCache(maxsize=3, ttl=60)
+        assert cache.get("nonexistent") is None
+
+    def test_contains(self):
+        """Test __contains__ method."""
+        cache = TTLLRUCache(maxsize=3, ttl=60)
+        cache.set("key1", "value1")
+        assert "key1" in cache
+        assert "key2" not in cache
+
+    def test_len(self):
+        """Test __len__ method."""
+        cache = TTLLRUCache(maxsize=3, ttl=60)
+        assert len(cache) == 0
+        cache.set("key1", "value1")
+        assert len(cache) == 1
+        cache.set("key2", "value2")
+        assert len(cache) == 2
+
+    def test_keys(self):
+        """Test keys method."""
+        cache = TTLLRUCache(maxsize=3, ttl=60)
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        keys = cache.keys()
+        assert "key1" in keys
+        assert "key2" in keys
+
+    def test_remove(self):
+        """Test remove method."""
+        cache = TTLLRUCache(maxsize=3, ttl=60)
+        cache.set("key1", "value1")
+        assert cache.remove("key1") is True
+        assert cache.get("key1") is None
+        assert cache.remove("key1") is False
+
+    def test_lru_eviction(self):
+        """Test LRU eviction when cache is full."""
+        cache = TTLLRUCache(maxsize=2, ttl=60)
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        # Access key1 to make it recently used
+        cache.get("key1")
+        # Add key3, should evict key2 (least recently used)
+        cache.set("key3", "value3")
+
+        assert cache.get("key1") == "value1"
+        assert cache.get("key3") == "value3"
+        # key2 should have been evicted
+        assert len(cache) == 2
+
+    def test_ttl_expiration(self):
+        """Test TTL expiration."""
+        cache = TTLLRUCache(maxsize=3, ttl=1)  # 1 second TTL
+        cache.set("key1", "value1")
+
+        # Should be available immediately
+        assert cache.get("key1") == "value1"
+
+        # Wait for TTL to expire
+        time.sleep(1.5)
+
+        # Should be expired
+        assert cache.get("key1") is None
+
+    def test_ttl_refresh_on_access(self):
+        """Test that TTL is refreshed on access."""
+        cache = TTLLRUCache(maxsize=3, ttl=2)  # 2 second TTL
+        cache.set("key1", "value1")
+
+        # Wait 1 second
+        time.sleep(1)
+
+        # Access to refresh TTL
+        assert cache.get("key1") == "value1"
+
+        # Wait another 1.5 seconds (would be expired without refresh)
+        time.sleep(1.5)
+
+        # Should still be available because we refreshed
+        assert cache.get("key1") == "value1"
+
+    def test_cleanup_expired(self):
+        """Test cleanup of expired entries."""
+        cache = TTLLRUCache(maxsize=3, ttl=1)
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+
+        # Wait for expiration
+        time.sleep(1.5)
+
+        # Cleanup should remove expired entries
+        expired = cache.cleanup_expired()
+        assert "key1" in expired
+        assert "key2" in expired
+        assert len(cache) == 0
+
+    def test_thread_safety(self):
+        """Test thread safety of cache operations."""
+        import threading
+
+        cache = TTLLRUCache(maxsize=100, ttl=60)
+        errors = []
+
+        def writer(start, count):
+            try:
+                for i in range(count):
+                    cache.set(f"key-{start + i}", f"value-{start + i}")
+            except Exception as e:
+                errors.append(e)
+
+        def reader():
+            try:
+                for _ in range(100):
+                    for key in cache.keys():
+                        cache.get(key)
+            except Exception as e:
+                errors.append(e)
+
+        threads = []
+        # Start multiple writers
+        for i in range(5):
+            t = threading.Thread(target=writer, args=(i * 20, 20))
+            threads.append(t)
+
+        # Start multiple readers
+        for _ in range(3):
+            t = threading.Thread(target=reader)
+            threads.append(t)
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0, f"Thread safety errors: {errors}"

--- a/tests/test_pid_manager.py
+++ b/tests/test_pid_manager.py
@@ -1,0 +1,137 @@
+"""Tests for PID manager."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mlx_serve.core.pid_manager import PIDManager, get_all_instances
+
+
+class TestPIDManager:
+    """Test PIDManager class."""
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path):
+        """Create a temporary directory for PID files."""
+        with patch.object(PIDManager, "_pid_dir", tmp_path):
+            yield tmp_path
+
+    def test_write_and_read_pid(self, temp_dir):
+        """Test writing and reading PID file."""
+        with patch.object(PIDManager, "_pid_dir", temp_dir):
+            manager = PIDManager(8000)
+            manager._pid_dir = temp_dir
+            manager._pid_file = temp_dir / "mlx-serve-8000.pid"
+
+            manager.write_pid(12345)
+            assert manager.read_pid() == 12345
+
+    def test_read_pid_not_exists(self, temp_dir):
+        """Test reading non-existent PID file."""
+        with patch.object(PIDManager, "_pid_dir", temp_dir):
+            manager = PIDManager(8000)
+            manager._pid_dir = temp_dir
+            manager._pid_file = temp_dir / "mlx-serve-8000.pid"
+
+            assert manager.read_pid() is None
+
+    def test_remove_pid(self, temp_dir):
+        """Test removing PID file."""
+        with patch.object(PIDManager, "_pid_dir", temp_dir):
+            manager = PIDManager(8000)
+            manager._pid_dir = temp_dir
+            manager._pid_file = temp_dir / "mlx-serve-8000.pid"
+
+            manager.write_pid(12345)
+            assert manager.remove_pid() is True
+            assert manager.read_pid() is None
+            assert manager.remove_pid() is False
+
+    def test_is_process_running_current_process(self, temp_dir):
+        """Test checking if current process is running."""
+        with patch.object(PIDManager, "_pid_dir", temp_dir):
+            manager = PIDManager(8000)
+            manager._pid_dir = temp_dir
+            manager._pid_file = temp_dir / "mlx-serve-8000.pid"
+
+            current_pid = os.getpid()
+            manager.write_pid(current_pid)
+            assert manager.is_process_running() is True
+
+    def test_is_process_running_dead_process(self, temp_dir):
+        """Test checking if dead process is running."""
+        with patch.object(PIDManager, "_pid_dir", temp_dir):
+            manager = PIDManager(8000)
+            manager._pid_dir = temp_dir
+            manager._pid_file = temp_dir / "mlx-serve-8000.pid"
+
+            # Use an extremely high PID that's unlikely to exist
+            manager.write_pid(999999999)
+            assert manager.is_process_running() is False
+
+    def test_is_stale(self, temp_dir):
+        """Test stale PID detection."""
+        with patch.object(PIDManager, "_pid_dir", temp_dir):
+            manager = PIDManager(8000)
+            manager._pid_dir = temp_dir
+            manager._pid_file = temp_dir / "mlx-serve-8000.pid"
+
+            # No PID file
+            assert manager.is_stale() is False
+
+            # Valid PID
+            manager.write_pid(os.getpid())
+            assert manager.is_stale() is False
+
+            # Stale PID
+            manager.write_pid(999999999)
+            assert manager.is_stale() is True
+
+    def test_cleanup_stale(self, temp_dir):
+        """Test stale PID cleanup."""
+        with patch.object(PIDManager, "_pid_dir", temp_dir):
+            manager = PIDManager(8000)
+            manager._pid_dir = temp_dir
+            manager._pid_file = temp_dir / "mlx-serve-8000.pid"
+
+            # Write stale PID
+            manager.write_pid(999999999)
+            assert manager._pid_file.exists()
+
+            # Cleanup should remove it
+            assert manager.cleanup_stale() is True
+            assert not manager._pid_file.exists()
+
+            # No more stale files
+            assert manager.cleanup_stale() is False
+
+    def test_pid_file_path(self):
+        """Test PID file path generation."""
+        manager = PIDManager(8080)
+        assert "mlx-serve-8080.pid" in str(manager.pid_file)
+
+
+class TestGetAllInstances:
+    """Test get_all_instances function."""
+
+    def test_no_instances(self, tmp_path):
+        """Test with no running instances."""
+        with patch("mlx_serve.core.pid_manager.Path.home", return_value=tmp_path):
+            instances = get_all_instances()
+            assert instances == []
+
+    def test_with_running_instance(self, tmp_path):
+        """Test with running instance."""
+        pid_dir = tmp_path / ".mlx-serve"
+        pid_dir.mkdir(parents=True)
+
+        # Write current process PID
+        (pid_dir / "mlx-serve-8000.pid").write_text(str(os.getpid()))
+
+        with patch("mlx_serve.core.pid_manager.Path.home", return_value=tmp_path):
+            instances = get_all_instances()
+            assert len(instances) == 1
+            assert instances[0] == (8000, os.getpid())

--- a/tests/test_service_manager.py
+++ b/tests/test_service_manager.py
@@ -1,0 +1,172 @@
+"""Tests for service manager."""
+
+import platform
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mlx_serve.core.service_manager import (
+    LaunchdManager,
+    SystemdManager,
+    get_platform_name,
+    get_service_manager,
+)
+
+
+class TestGetServiceManager:
+    """Test get_service_manager function."""
+
+    def test_darwin(self):
+        """Test macOS detection."""
+        with patch("platform.system", return_value="Darwin"):
+            manager = get_service_manager()
+            assert isinstance(manager, LaunchdManager)
+
+    def test_linux(self):
+        """Test Linux detection."""
+        with patch("platform.system", return_value="Linux"):
+            manager = get_service_manager()
+            assert isinstance(manager, SystemdManager)
+
+    def test_windows(self):
+        """Test Windows (unsupported)."""
+        with patch("platform.system", return_value="Windows"):
+            manager = get_service_manager()
+            assert manager is None
+
+
+class TestGetPlatformName:
+    """Test get_platform_name function."""
+
+    def test_darwin(self):
+        """Test macOS name."""
+        with patch("platform.system", return_value="Darwin"):
+            assert get_platform_name() == "macOS (launchd)"
+
+    def test_linux(self):
+        """Test Linux name."""
+        with patch("platform.system", return_value="Linux"):
+            assert get_platform_name() == "Linux (systemd)"
+
+    def test_other(self):
+        """Test other platform name."""
+        with patch("platform.system", return_value="FreeBSD"):
+            assert get_platform_name() == "FreeBSD"
+
+
+class TestLaunchdManager:
+    """Test LaunchdManager class."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create manager with temporary paths."""
+        manager = LaunchdManager()
+        manager._plist_path = tmp_path / "com.mlx-serve.server.plist"
+        manager._log_dir = tmp_path / "logs"
+        return manager
+
+    def test_service_name(self, manager):
+        """Test service name."""
+        assert manager.service_name == "com.mlx-serve.server"
+
+    def test_is_installed_false(self, manager):
+        """Test is_installed when not installed."""
+        assert manager.is_installed is False
+
+    def test_is_installed_true(self, manager):
+        """Test is_installed when installed."""
+        manager._plist_path.parent.mkdir(parents=True, exist_ok=True)
+        manager._plist_path.write_text("<plist>test</plist>")
+        assert manager.is_installed is True
+
+    def test_install(self, manager):
+        """Test install creates plist file."""
+        success, message = manager.install()
+        assert success is True
+        assert manager._plist_path.exists()
+        content = manager._plist_path.read_text()
+        assert "com.mlx-serve.server" in content
+        assert "RunAtLoad" in content
+
+    def test_install_with_run_at_load(self, manager):
+        """Test install with run_at_load enabled."""
+        success, _ = manager.install(run_at_load=True)
+        assert success is True
+        content = manager._plist_path.read_text()
+        assert "<true/>" in content.split("RunAtLoad")[1].split("\n")[1]
+
+    def test_uninstall(self, manager):
+        """Test uninstall removes plist file."""
+        manager.install()
+        assert manager._plist_path.exists()
+
+        with patch("subprocess.run"):
+            success, message = manager.uninstall()
+
+        assert success is True
+        assert not manager._plist_path.exists()
+
+    def test_status(self, manager):
+        """Test status returns correct info."""
+        with patch.object(manager, "is_running", False):
+            status = manager.status()
+            assert status["installed"] is False
+            assert status["running"] is False
+            assert status["service_name"] == "com.mlx-serve.server"
+
+
+class TestSystemdManager:
+    """Test SystemdManager class."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create manager with temporary paths."""
+        manager = SystemdManager()
+        manager._service_dir = tmp_path / "systemd" / "user"
+        manager._service_path = manager._service_dir / "mlx-serve.service"
+        return manager
+
+    def test_service_name(self, manager):
+        """Test service name."""
+        assert manager.service_name == "mlx-serve"
+
+    def test_is_installed_false(self, manager):
+        """Test is_installed when not installed."""
+        assert manager.is_installed is False
+
+    def test_is_installed_true(self, manager):
+        """Test is_installed when installed."""
+        manager._service_dir.mkdir(parents=True, exist_ok=True)
+        manager._service_path.write_text("[Unit]\ntest")
+        assert manager.is_installed is True
+
+    def test_install(self, manager):
+        """Test install creates service file."""
+        with patch("subprocess.run"):
+            success, message = manager.install()
+
+        assert success is True
+        assert manager._service_path.exists()
+        content = manager._service_path.read_text()
+        assert "[Unit]" in content
+        assert "[Service]" in content
+        assert "[Install]" in content
+
+    def test_uninstall(self, manager):
+        """Test uninstall removes service file."""
+        with patch("subprocess.run"):
+            manager.install()
+            assert manager._service_path.exists()
+
+            success, message = manager.uninstall()
+
+        assert success is True
+        assert not manager._service_path.exists()
+
+    def test_status(self, manager):
+        """Test status returns correct info."""
+        with patch.object(manager, "is_running", False):
+            status = manager.status()
+            assert status["installed"] is False
+            assert status["running"] is False
+            assert status["service_name"] == "mlx-serve"


### PR DESCRIPTION
## Summary
- Add PID-based server lifecycle control (start/stop/status commands)
- Implement LRU+TTL model caching for memory management
- Add reranker return_text option with decision threshold
- Add model preloading via CLI and environment variable
- Add cross-platform service management (macOS launchd + Linux systemd)
- Add enable/disable commands for auto-start at login

## Test Plan
- [x] Run unit tests for PIDManager, TTLLRUCache, ServiceManager
- [x] Test server start/stop/status commands
- [x] Test model caching with LRU eviction and TTL expiration
- [x] Test reranker API with return_text option
- [x] Test preload functionality
- [x] Test service install/start/stop/status/enable/disable

Closes #2

---
🤖 Auto-generated by coni